### PR TITLE
Fix newline before catch block

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -115,7 +115,8 @@ document.addEventListener('DOMContentLoaded', function() {  const apiKeyInput = 
         showStatus('Ideas generated successfully!', 'success');
       } else {
         throw new Error(response.error || 'Failed to generate ideas');
-      }    } catch (error) {
+      }
+    } catch (error) {
       console.error('Error:', error);
       
       // Provide more specific error messages


### PR DESCRIPTION
## Summary
- clean up popup.js by moving `catch` onto its own line

## Testing
- `node --check popup.js`

------
https://chatgpt.com/codex/tasks/task_e_6843f5ec44ac8325a67ac767cdb0f48c